### PR TITLE
fix(all): manage to get docker ip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@
 GO=$(firstword $(subst :, ,$(GOPATH)))
 # list of pkgs for the project without vendor
 PKGS=$(shell go list ./... | grep -v /vendor/)
-DOCKER_IP=$(shell docker-mahine ip default)
+DOCKER_IP=$(shell if [ -z "$(DOCKER_MACHINE_NAME)" ]; then echo 'localhost'; else docker-machine ip $(DOCKER_MACHINE_NAME); fi)
 export GO15VENDOREXPERIMENT=1
 
 # -----------------------------------------------------------------

--- a/etc/apiquery.sh
+++ b/etc/apiquery.sh
@@ -4,8 +4,8 @@
 
 # check if running on osx or linux
 IP=127.0.0.1
-if [ `uname -s` == "Darwin" ]; then
-  IP=$(docker-machine ip)
+if [ -z "$DOCKER_MACHINE_NAME" ]; then
+  IP=$(docker-machine ip $DOCKER_MACHINE_NAME)
 fi
 
 echo "Create spirit from file..."


### PR DESCRIPTION
The current `DOCKER_IP`initialization is only for `OSX` (with a typo on `docker-machine`).

I fix this initialization to 
- use the right docker machine ip
- otherwise, it's localhost

Same as in `etc/apiquery.sh`

env variable `DOCKER_MACHINE_NAME` is set when `docker-machine env` command is run.
